### PR TITLE
Update 1.12.2.md

### DIFF
--- a/mods-n-stuff/1.12.2.md
+++ b/mods-n-stuff/1.12.2.md
@@ -7,7 +7,7 @@
 | Alfheim Lighting Engine | Alpha 1.6-Dev.2 doesn't download Red Core automatically, you must do it yourself | Server |
 | CensoredASM | - | Both |
 | Entity Culling | There are 2 mods going by that name, the one I'd recommend is by tr7zw. There is an edge case where Entity Culling can crash the game. See [this](https://github.com/CaffeineMC/sodium/issues/2985) for more info | Client |
-| Fixeroo | - | Both |
+| Fixeroo | Will creak custom block rendering for mods like Buildcraft, ExCompressum and etc. | Both |
 | Nothirium | If you're using CensoredASM, install Naughthirium as well, otherwise animations won't work | Client |
 | StellarCore | `ParallelModelLoader` must be disabled if using VintageFix. You can also enable `AlwaysDeferChunkUpdates`, `HUDCaching` and `NoGLError` | Both |
 | UniversalTweaks | - | Both |


### PR DESCRIPTION
Added a incompatibility note for Fixeroo when mods like Buildcraft and ExCompressum are pressent.