### PR TITLE
Add a fix for NNBSP characters.

### DIFF
--- a/java-n-stuff/java-things.md
+++ b/java-n-stuff/java-things.md
@@ -42,7 +42,7 @@
 
 For versions 11w49a-23w17a, on Java 20 and newer, a NNBSP (Narrow No-Break Space) character can show up in DateFormat outputs.
 
-This will render as a dotted box with surrounding the text "nnbsp" and will appear near timestamps (most commonly).
+This will render as a dotted box with surrounding the text "NNBSP" and will appear near timestamps (most commonly).
 
 To fix this add the argument:
 

--- a/java-n-stuff/java-things.md
+++ b/java-n-stuff/java-things.md
@@ -38,6 +38,18 @@
 
 # JVM Arguments
 
+### DateFormat Fix
+
+For versions 11w49a-23w17a, on Java 20 and newer, a NNBSP (Narrow No-Break Space) character can show up in DateFormat outputs.
+
+This will render as a dotted box with surrounding the text "nnbsp" and will appear near timestamps (most commonly).
+
+To fix this add the argument:
+
+``
+-Djava.locale.providers=JRE
+``
+
 ### Generational ZGC (GenZGC)
 
 If you're on a version which supports Java 21 or newer and your PC has at least 16 GB of RAM, I'd recommend using GenZGC, as it can greatly reduce stutters. You can enable it with these args:


### PR DESCRIPTION
While playing Divine Journey 2 (1.12.2) using GraalVM 25, I noticed that NNBSP characters would appear near timestamps.

After a digging around for fixes, I stumbled across this mod: https://modrinth.com/mod/nnbsp-fix

> Fixes the NNBSP character in DateFormat outputs in Java 20+ as caused by the CLDR Unicode v42 update. This was fixed in 23w17a (1.20-alpha.23.17.a) though a font rendering revamp and was introduced in 11w49a (1.1-alpha.11.49.a), the same version that put the Save and Quit to Title button into title case. Another way of fixing this would be to set the java property -Djava.locale.providers=JRE (or COMPAT, they are the same), but that legacy locale provider is set to be removed in the future.

I have added a note to the Java Arguments section about this.